### PR TITLE
Modified cmakelist to ensure compilation

### DIFF
--- a/src/blockchain_db/CMakeLists.txt
+++ b/src/blockchain_db/CMakeLists.txt
@@ -29,6 +29,11 @@
 set(blockchain_db_sources
   blockchain_db.cpp
   lmdb/db_lmdb.cpp
+  ../cryptonote_core/cryptonote_tx_utils.cpp
+  ../cryptonote_core/blockchain.cpp
+  ../cryptonote_core/tx_pool.cpp
+  ../cryptonote_core/tx_verification_utils.cpp
+  ../hardforks/hardforks.cpp
   )
 
 set(blockchain_db_headers)


### PR DESCRIPTION
Hi guys, I found an error in the cmakelist file, which caused the .so files to not compile properly:
`cmake -DBUILD_SHARED_LIBS=1 -DMANUAL_SUBMODULES=1 .`
`make -j4`
Then you will see the "undefined reference" compilation error. I modified cmakelist to fix this error and now it compiles fine. I hope this helps.